### PR TITLE
fix: Fix command line arguments & add note about Postgres default port pitfalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ npm run migrate
 
 This will prompt you to give a name for the migration.
 
+### NOTE:
+
+When running `npm run migrate`, if you see the error
+
+```
+Error: P1000: Authentication failed against database server at `localhost`, the provided database credentials for `test-user` are not valid.
+```
+
+check if you are already running a Postgres server instance on your machine with the default port also given in this tutorial (5432). If so, you will need to stop the machine instance of Postgres for the credentials to successfully work.
+
 To access the data in the database, you'll need to make use of Prisma Client.
 
 You just need to uncomment this line in the `index.ts` file:

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": ".ts,.js",
   "ignore": [],
-  "exec": "ts-node ./src/index.ts"
+  "exec": "./node_modules/.bin/ts-node ./src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon",
     "build": "rimraf ./build && tsc",
     "start": "npm run build && node build/index.js",
-    "migrate": "npx prisma migrate dev"
+    "migrate": "prisma migrate dev"
   },
   "author": "Tom Ray",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

* Specifies `ts-node` package to execute
  * The current given command relies on a global installation of `ts-node`. The suggested fix points at the recently-installed local instance in `/node_modules/.bin/`
* Specifies Prisma CLI package to execute
  * The current given command will reach out to the `npx` registry for the latest version of Prisma CLI. The suggested fix points at the recently-installed local instance in `/node_modules`
* Adds a warning around the pitfalls of using default suggested Postgres port numbers
  * See changes in `README.md` for further details. Solution found with help from this SO answer: https://stackoverflow.com/a/59631364/4289365
  
Would love to help out by adding these changes to the blogpost source as well, but I wasn't able to immediately find that. Cheers @tomwray13 , thanks for the tutorial!